### PR TITLE
fix: switch ongeki calculation to fixed-point arithmetic

### DIFF
--- a/library/src/algorithms/ongeki-rating.test.ts
+++ b/library/src/algorithms/ongeki-rating.test.ts
@@ -39,6 +39,7 @@ t.test("O.N.G.E.K.I. Rating Edge Cases", (t) => {
 	);
 	t.equal(calculate(0, 12.5), 0, "A score of 0 should be worth 0.");
 	t.equal(calculate(0, 0), 0, "A score of 0 on a chart with level 0 should be worth 0.");
+	t.equal(calculate(1_007_880, 14.4), 16.4, "An SSS+ on a 14.4 should be worth 16.4.")
 
 	t.end();
 });

--- a/library/src/algorithms/ongeki-rating.ts
+++ b/library/src/algorithms/ongeki-rating.ts
@@ -1,4 +1,3 @@
-import { FloorToNDP } from "../util/math";
 import { ThrowIf } from "../util/throw-if";
 
 /**
@@ -16,16 +15,17 @@ export function calculate(technicalScore: number, internalChartLevel: number) {
 	ThrowIf.negative(internalChartLevel, "Chart level cannot be negative.", { internalChartLevel });
 
 	let ratingValue = 0;
+	const iclInt = Math.round(internalChartLevel * 100.0);
 
 	if (technicalScore >= 1_007_500) {
-		ratingValue = internalChartLevel + 2;
+		ratingValue = iclInt + 200;
 	} else if (technicalScore >= 1_000_000) {
-		ratingValue = internalChartLevel + 1.5 + (technicalScore - 1_000_000) / 15_000;
+		ratingValue = iclInt + 150 + Math.floor((technicalScore - 1_000_000) / 150);
 	} else if (technicalScore >= 970_000) {
-		ratingValue = internalChartLevel + (technicalScore - 970_000) / 20_000;
+		ratingValue = iclInt + Math.floor((technicalScore - 970_000) / 200);
 	} else {
-		ratingValue = internalChartLevel - (970_000 - technicalScore) / 17_500;
+		ratingValue = iclInt - Math.ceil((970_000 - technicalScore) / 175);
 	}
 
-	return FloorToNDP(Math.max(ratingValue, 0), 2);
+	return Math.max(ratingValue / 100.0, 0);
 }


### PR DESCRIPTION
With floating-point arithmetic, some edge cases (such as an SSS+ on a 14.4) yield incorrect results.