### PR TITLE
fix(maimaidx): lower all perfect threshold

### DIFF
--- a/library/src/algorithms/maimaidx-rate.test.ts
+++ b/library/src/algorithms/maimaidx-rate.test.ts
@@ -32,6 +32,7 @@ t.test("maimai DX Rate Tests", (t) => {
 		MakeTestCase(100.5, 13, "ALL PERFECT", 293),
 		MakeTestCase(100.5, 13, "CLEAR", 292),
 		MakeTestCase(100.4999, 14, "CLEAR", 312),
+		MakeTestCase(100, 13, "ALL PERFECT", 281),
 		MakeTestCase(100, 13, "CLEAR", 280),
 		MakeTestCase(99.9999, 13.7, "CLEAR", 293),
 		MakeTestCase(99.5, 13.7, "CLEAR", 287),
@@ -95,8 +96,8 @@ t.test("maimai DX Rate Validation Tests", (t) => {
 	);
 	ThrowsToSnapshot(
 		t,
-		() => calculate(100.4, 10, "ALL PERFECT"),
-		"Should throw if lamp is ALL PERFECT but score is below 100.5%."
+		() => calculate(99.9, 10, "ALL PERFECT"),
+		"Should throw if lamp is ALL PERFECT but score is below 100%."
 	);
 	ThrowsToSnapshot(
 		t,

--- a/library/src/algorithms/maimaidx-rate.ts
+++ b/library/src/algorithms/maimaidx-rate.ts
@@ -61,8 +61,8 @@ export function calculate(score: number, internalChartLevel: number, lamp?: Maim
 		{ score, lamp }
 	);
 	ThrowIf(
-		lamp === "ALL PERFECT" && score < 100.5,
-		"Cannot have an ALL PERFECT without at least 100.5%.",
+		lamp === "ALL PERFECT" && score < 100,
+		"Cannot have an ALL PERFECT without at least 100%.",
 		// @ts-expect-error Lamp is "ALL PERFECT" if the exception is thrown.
 		{ score, lamp }
 	);

--- a/library/tap-snapshots/src/algorithms/maimaidx-rate.test.ts.test.cjs
+++ b/library/tap-snapshots/src/algorithms/maimaidx-rate.test.ts.test.cjs
@@ -5,8 +5,8 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`src/algorithms/maimaidx-rate.test.ts TAP maimai DX Rate Validation Tests > Should throw if lamp is ALL PERFECT but score is below 100.5%. 1`] = `
-Invalid input, Cannot have an ALL PERFECT without at least 100.5%. score=100.4, lamp="ALL PERFECT".
+exports[`src/algorithms/maimaidx-rate.test.ts TAP maimai DX Rate Validation Tests > Should throw if lamp is ALL PERFECT but score is below 100%. 1`] = `
+Invalid input, Cannot have an ALL PERFECT without at least 100%. score=99.9, lamp="ALL PERFECT".
 `
 
 exports[`src/algorithms/maimaidx-rate.test.ts TAP maimai DX Rate Validation Tests > Should throw if lamp is ALL PERFECT+ but score is not 101%. 1`] = `


### PR DESCRIPTION
Currently, maimai DX's minimum score for an ALL PERFECT is 100.5%, since:
- The 101% is split into 2 components, 100% base score and 1% break score
- All note types award 100% base score on a PERFECT judgement
- Break notes award 0.5%/0.75%/1% break score on PERFECT based on how precisely it was hit

Therefore, the minimum ALL PERFECT score is achieved when you hit all breaks on the 0.5% window => 100.5%. 

However, there was a short 1-month period where the break bonuses were 0%/0.5%/1% instead ([official changelog](https://maimai.sega.jp/news/2019-08-07/)), so the lowest ALL PERFECT score is 100%.

While this doesn't affect any future scores (so the Tachi validation rule can stay at 100.5%), there are a few scores on Tachi that were made on the old break scoring rules, failing the old validation rules and breaking the recalc.